### PR TITLE
Fix for RT:78278

### DIFF
--- a/lib/Text/CSV/Slurp.pm
+++ b/lib/Text/CSV/Slurp.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Text::CSV;
-use IO::Handle;
+use IO::File;
 
 use vars qw/$VERSION/;
 
@@ -32,7 +32,7 @@ sub load {
     return _from_handle($io,\%opt);
   }
   elsif (defined $opt{file}) {
-    my $io = new IO::Handle;
+    my $io = new IO::File;
     open($io, "<$opt{file}") || die "Could not open $opt{file} $!";
     delete $opt{file};
     return _from_handle($io,\%opt);


### PR DESCRIPTION
I also got hit by this bug:

  https://rt.cpan.org/Public/Bug/Display.html?id=78278

Opening the file as an IO::Handle means it doesn't have the tell() method which Text::CSV::XS expects.
Changing this to an IO::File fixes it.

BTW, thanks for the module - exactly what I was looking for!
